### PR TITLE
AMQNET-593: Add IsCompositeUri utility method

### DIFF
--- a/src/nms-api/Util/URISupport.cs
+++ b/src/nms-api/Util/URISupport.cs
@@ -605,6 +605,23 @@ namespace Apache.NMS.Util
 			l.CopyTo(rc);
 			return rc;
 		}
+		
+		/// <summary>
+		/// Examine a Uri and determine if it is a Composite type or not.
+		/// </summary>
+		/// <param name="uri">The Uri that is to be examined.</param>
+		/// <returns>true if the given URI is a Composite type.</returns>
+		public static bool IsCompositeUri(Uri uri)
+		{
+			string ssp = StripPrefix(uri.PathAndQuery.Trim(), "//").Trim();
+
+			if (ssp.IndexOf('(') == 0 && CheckParenthesis(ssp))
+			{
+				return true;
+			}
+
+			return false;
+		}
 
 		public static bool CheckParenthesis(String str)
 		{

--- a/test/nms-api-test/URISupportTest.cs
+++ b/test/nms-api-test/URISupportTest.cs
@@ -296,6 +296,39 @@ namespace Apache.NMS.Test
             NUnit.Framework.Assert.AreEqual(paramValue, value);
         }
 #endif
+		
+		[Test]
+		public void TestIsCompositeUriWithQueryNoSlashes()
+		{
+			Uri[] compositeUrIs = { new Uri("test:(part1://host?part1=true)?outside=true"), new Uri("broker:(tcp://localhost:61616)?name=foo") };
+			foreach (Uri uri in compositeUrIs)
+			{
+				Assert.True(URISupport.IsCompositeUri(uri), uri + "must be detected as composite URI");
+			}
+		}
+
+		[Test]
+		public void TestIsCompositeUriNoQueryNoSlashes()
+		{
+			Uri[] compositeUrIs = new Uri[] { new Uri("test:(part1://host,part2://(sub1://part,sube2:part))"), new Uri("test:(path)/path") };
+			foreach (Uri uri in compositeUrIs)
+			{
+				Assert.True(URISupport.IsCompositeUri(uri), uri + "must be detected as composite URI");
+			}
+		}
+
+		[Test]
+		public void TestIsCompositeWhenUriHasUnmatchedParentheses()
+		{
+			Uri uri = new Uri("test:(part1://host,part2://(sub1://part,sube2:part)");
+			Assert.False(URISupport.IsCompositeUri(uri));
+		}
+
+		[Test]
+		public void TestIsCompositeUriNoQueryNoSlashesNoParentheses()
+		{
+			Assert.False(URISupport.IsCompositeUri(new Uri("test:part1")), "test:part1" + " must be detected as non-composite URI");
+		}
 	}
 }
 


### PR DESCRIPTION
I would like to extend URISupport class with IsCompositeUri utility method to determine if passed Uri is composite type or not.

The method is already defined in NMS AMQP  but I think it makes sense to move it API where the rest of URISupport is defined. 

https://github.com/apache/activemq-nms-amqp/blob/2d565c7dcf41135f77bb5225d05d2e0d21c60696/src/NMS.AMQP/Util/URISupport.cs