### PR TITLE
AMQNET-631: Restore session extensions api

### DIFF
--- a/src/nms-api/SessionExtensions.cs
+++ b/src/nms-api/SessionExtensions.cs
@@ -20,7 +20,6 @@ using Apache.NMS.Util;
 
 namespace Apache.NMS
 {
-#if NET_3_5 || MONO
 	public static class SessionExtensions
 	{
 		/// <summary>
@@ -97,5 +96,4 @@ namespace Apache.NMS
 			SessionUtil.DeleteDestination(session, topicName);
 		}
 	}
-#endif
 }


### PR DESCRIPTION
This PR addresses a change requested via mailing list. Waiting for jira Issue.

> I have tried updating the Apache.ActiveMQ.NMS Nuget package to 1.8.0 in my
> project, and am getting build errors indicating that the GetDestination
> method is not available on ISession.
> 
> This method is defined in the SessionExtensions class, but it is
> conditionally compiled only if the symbol MONO or NET_3_5 is defined.
> 
> I assume that this was defined previously, but is now inadvertently omitted
> as part of the restructuring that was done for 1.8. Probably, the extension
> methods could be defined for any supported version of .NET at this point,
> as .NET < 3.5 is no longer supported by the project.
> 
> The extension method simply delegates to SessionUtil.GetDestination, which
> is exposed to public as well, so for my immediate need I just called that
> directly.
> However, I assume this should not have been necessary and that the
> extension methods should still be provided as before, rather than have a
> breaking change.