### PR TITLE
AMQNET-638 Add SourceLink support

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 $pkgname = "Apache.NMS"
-$pkgver = "1.8.0"
+$pkgver = "1.8.1"
 $frameworks = "net35", "net40", "netstandard2.0"
 
 write-progress "Creating package directory." "Initializing..."
@@ -51,6 +51,10 @@ if (test-path build) {
     $nupkg = "$pkgname.$pkgver.nupkg"
     $nupkgdestination = "$pkgdir\$nupkg"
     Copy-Item -Path $nupkg -Destination $nupkgdestination
+
+    $snupkg = "$pkgname.$pkgver.snupkg"
+    $snupkgdestination = "$pkgdir\$snupkg"
+    Copy-Item -Path $snupkg -Destination $snupkgdestination
 
     # clean up temp
     Remove-Item temp -Recurse -ErrorAction Inquire

--- a/src/nms-api/nms-api.csproj
+++ b/src/nms-api/nms-api.csproj
@@ -32,7 +32,7 @@ with the License.  You may obtain a copy of the License at
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Apache.NMS</PackageId>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <Authors>Apache ActiveMQ</Authors>
     <Company>Apache Software Foundation</Company>
     <Product>Apache NMS API</Product>
@@ -46,6 +46,20 @@ with the License.  You may obtain a copy of the License at
     <PackageTags>apache;activemq;nms;api;net;messaging</PackageTags>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
+
+  <!-- SourceLink Start -->
+  <PropertyGroup>
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Add PackageReference specific for your source control provider (see below) -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+  <!-- SourceLink End -->
 
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>


### PR DESCRIPTION
I'd like to add SourceLink support to this library in order to simplify debugging from referencing projects.


Please take a look into the small demo of SourceLink in action 

![0YU7WcwFXa](https://user-images.githubusercontent.com/290543/78409972-cc2a4580-7613-11ea-848f-22b6ceb501c4.gif)

For more details on how to enable debugging with SourceLink please check the following guides:

- [How to Configure Visual Studio to Use SourceLink to Step into NuGet Package Source](http://www.aaronstannard.com/visual-studio-sourcelink-setup/)
- [Debugging into NuGet packages with SourceLink in Visual Studio for Mac](https://docs.microsoft.com/en-us/visualstudio/mac/source-link?view=vsmac-2019)


For more details on SoureLink, please navigate the following links:

- [dotnet/sourcelink](https://github.com/dotnet/sourcelink)
- [SourceLink file specification](https://github.com/dotnet/designs/blob/master/accepted/2020/diagnostics/source-link.md#source-link-file-specification)