### PR TITLE
[AMQNET-851] Support amqps uri schemas

### DIFF
--- a/src/nms-api/NMSConnectionFactory.cs
+++ b/src/nms-api/NMSConnectionFactory.cs
@@ -75,6 +75,8 @@ namespace Apache.NMS
                 new ProviderFactoryInfo("Apache.NMS.ZMQ", "Apache.NMS.ZMQ.ConnectionFactory");
             schemaProviderFactoryMap["amqp"] =
                 new ProviderFactoryInfo("Apache.NMS.AMQP", "Apache.NMS.AMQP.ConnectionFactory");
+            schemaProviderFactoryMap["amqps"] =
+                new ProviderFactoryInfo("Apache.NMS.AMQP", "Apache.NMS.AMQP.ConnectionFactory");
         }
 
         /// <summary>

--- a/src/nms-api/NMSConnectionFactory.cs
+++ b/src/nms-api/NMSConnectionFactory.cs
@@ -77,6 +77,8 @@ namespace Apache.NMS
                 new ProviderFactoryInfo("Apache.NMS.AMQP", "Apache.NMS.AMQP.ConnectionFactory");
             schemaProviderFactoryMap["amqps"] =
                 new ProviderFactoryInfo("Apache.NMS.AMQP", "Apache.NMS.AMQP.ConnectionFactory");
+            schemaProviderFactoryMap["failover"] =
+                new ProviderFactoryInfo("Apache.NMS.AMQP", "Apache.NMS.AMQP.ConnectionFactory");
         }
 
         /// <summary>


### PR DESCRIPTION
The documentation would suggest that you can just use amqps:// uris with the nms.amqp provider, but sadly this doesn't work without a specific config file.

Secure amqps should work, and should not need extra work.